### PR TITLE
Make sure requests close their network connection

### DIFF
--- a/UniWebServer/Assets/UniWebServer/Lib/Request.cs
+++ b/UniWebServer/Assets/UniWebServer/Lib/Request.cs
@@ -31,7 +31,9 @@ namespace UniWebServer
 
         public void Close ()
         {
-			
+		if (stream != null) {
+			stream.Close();
+		}
         }
 
         public override string ToString ()


### PR DESCRIPTION
If a request doesn't close the network connection/stream then the connection will remain open and browsers/curl will wait forever (or atleast 30 seconds) for the connection to close.