### PR TITLE
Add headers creation in Response constructor

### DIFF
--- a/UniWebServer/Assets/UniWebServer/Lib/Response.cs
+++ b/UniWebServer/Assets/UniWebServer/Lib/Response.cs
@@ -18,6 +18,7 @@ namespace UniWebServer
 
         public Response ()
         {
+            headers = new Headers();
             stream = new MemoryStream();
             writer = new StreamWriter (stream);
         }


### PR DESCRIPTION
Hi guys! Many thanks for your work! I use this server in many projects and it works perfectly.
Just wanted to fix an unexpected behavior when adding headers to the Response. It happens when I return JSON object and set the MIME type. The response is `object reference not set to an instance of an object` with no more info or errors, so it is not easy to guess that the headers object is null.